### PR TITLE
メッセージ送信の非同期通信化の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
@@ -74,4 +74,4 @@ gem 'font-awesome-sass'
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
-
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,10 @@ GEM
     io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.3.5)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -250,9 +254,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -286,6 +287,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails
   jbuilder (~> 2.5)
+  jquery-rails
   listen
   meta-tags
   mini_magick
@@ -299,7 +301,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,8 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
-//= require activestorage
-//= require turbolinks
 //= require_tree .
+
+//= require activestorage

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,65 @@
+$(function(){ 
+  function buildHTML(message){
+   if ( message.image ) {
+     var html =
+      `<div class="message">
+         <div class="upper-message">
+           <div class="upper-message__user-name">
+             ${message.user_name}
+           </div>
+           <div class="upper-message__date">
+             ${message.created_at}
+           </div>
+         </div>
+         <div class="lower-message">
+           <p class="lower-message__content">
+             ${message.content}
+           </p>
+         </div>
+         <img src=${message.image} >
+       </div>`
+     return html;
+   } else {
+     var html =
+      `<div class="message">
+         <div class="upper-message">
+           <div class="upper-message__user-name">
+             ${message.user_name}
+           </div>
+           <div class="upper-message__date">
+             ${message.created_at}
+           </div>
+         </div>
+         <div class="lower-message">
+           <p class="lower-message__content">
+             ${message.content}
+           </p>
+         </div>
+       </div>`
+     return html;
+   };
+ }
+$('#new_message').on('submit', function(e){
+ e.preventDefault();
+ var formData = new FormData(this);
+ var url = $(this).attr('action')
+ $.ajax({
+   url: url,
+   type: "POST",
+   data: formData,
+   dataType: 'json',
+   processData: false,
+   contentType: false
+ })
+  .done(function(data){
+    var html = buildHTML(data);
+    $('.chat-bar__header__contents').append(html);      
+    $('form')[0].reset();
+    $('.chat-bar__header__contents').animate({ scrollTop: $('.chat-bar__header__contents')[0].scrollHeight});
+    $('.submit-btn').prop('disabled', false);
+  })
+  .fail(function() {
+    alert("メッセージ送信に失敗しました");
+});
+})
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,8 +5,8 @@
     %title ChatSpace
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -21,3 +21,5 @@
             = icon('fas','image', class: 'icon')
             = f.file_field :image, class: 'input-box__image__file'
         = f.submit 'Send', class: 'submit-btn'
+        
+         

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+
+
 module ChatSpace
   class Application < Rails::Application
     config.load_defaults 5.2
@@ -16,5 +18,6 @@ module ChatSpace
       g.helper false
       g.test_framework false
     end
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# what
chat-spaceのメッセージの送信機能の実装する。
js関係のディレクトリを追加。
以下にgifのキャプチャを添付する。
https://gyazo.com/7cf67347694d3c4bef826fed9a0535b1


#  why
実装前はコメントを送信すると、送信画面にリダイレクトするのでビューが毎回再描画されるが
非同期通信の実装を行うことで、コメントの送信を非同期で行えるようにした。


